### PR TITLE
Updated handling of oc_action to be more robust

### DIFF
--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -76,6 +76,7 @@ openshift_cluster_content:
   - name: <definition_name>
     helm:
       name: <helm chart name>  # Required
+      action: <template|install> # Optional: defaults to 'template'
       chart: <helm chart source> # Required
       version: <chart version to use> # Optional
       namespace: <namespace scope> # Optional 

--- a/roles/openshift-applier/defaults/main.yml
+++ b/roles/openshift-applier/defaults/main.yml
@@ -1,9 +1,30 @@
 ---
-client: oc
-default_oc_action: apply
+
 tmp_inv_dir: ''
+
 include_tags: ''
 exclude_tags: ''
+
 provision: true
+
 params_from_vars: {}
+
+
+
+##########################################################################################
+### OpenShift Client options
+# these default values are meant to be replaced runtime if other values are to be used
+# - for example 'client=kubectl'
+
+client: oc
+default_oc_action: apply
 oc_ignore_unknown_parameters: true
+
+oc_action_command: >-
+  | {{ client }} {{ oc_action }} \
+      {{ target_namespace }} \
+      -f - \
+      {{ (oc_action | regex_search('delete')) | ternary(' --ignore-not-found', '') }} \
+      {{ (client == 'kubectl' and not (oc_action | regex_search('delete|patch'))) | ternary(' --validate=false', '') }} \
+      {{ flags }}
+

--- a/roles/openshift-applier/tasks/process-helm.yml
+++ b/roles/openshift-applier/tasks/process-helm.yml
@@ -29,9 +29,9 @@
     helm_values_option: "{{ helm_values_option }} --values '{{ item }}'"
   loop: "{{ helm.values_param | default([]) }}"
 
-- name: "Helm install chart to target Openshift cluster: '{{ entry.object }} : {{ content.name | default(helm.name) }}'"
+- name: "{{ oc_action | capitalize }} OpenShift objects based on helm template for '{{ entry.object }} : {{ content.name | default(helm.name) }}'"
   shell: >
-    helm install \
+    helm {{ helm.action|d('template') }} \
        {{ helm.name }} {{ helm.chart }} \
        {{ helm_version_option }} \
        {{ helm_namespace_option }} \
@@ -39,9 +39,9 @@
        {{ helm_set_option }} \
        {{ helm_values_option }} \
        {{ helm.flags|d('') }} \
+       {{ (helm.action|d('template') == 'template') | ternary(oc_action_command, '') }}
   register: command_result
   no_log: "{{ no_log }}"
   failed_when:
     - command_result.rc != 0
     - "'AlreadyExists' not in command_result.stderr"
-

--- a/roles/openshift-applier/tasks/process-helm.yml
+++ b/roles/openshift-applier/tasks/process-helm.yml
@@ -29,7 +29,7 @@
     helm_values_option: "{{ helm_values_option }} --values '{{ item }}'"
   loop: "{{ helm.values_param | default([]) }}"
 
-- name: "{{ oc_action | capitalize }} OpenShift objects based on helm template for '{{ entry.object }} : {{ content.name | default(helm.name) }}'"
+- name: "Process OpenShift objects based on helm content for '{{ entry.object }} : {{ content.name | default(helm.name) }}'"
   shell: >
     helm {{ helm.action|d('template') }} \
        {{ helm.name }} {{ helm.chart }} \

--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -73,13 +73,7 @@
        {{ oc_param_option }} \
        {{ (oc_param_file_item.oc_path|trim == '') | ternary('', ' --param-file="' + oc_param_file_item.oc_path + '"') }} \
        {{ oc_ignore_unknown_parameters | ternary('--ignore-unknown-parameters', '') }} \
-       | \
-    {{ client }} {{ oc_action }} \
-       {{ target_namespace }} \
-       -f - \
-       {{ (oc_action | regex_search('delete')) | ternary(' --ignore-not-found', '') }} \
-       {{ (client == 'kubectl' and not (oc_action | regex_search('delete|patch'))) | ternary(' --validate=false', '') }} \
-       {{ flags }}
+       {{ oc_action_command }}
   register: command_result
   no_log: "{{ no_log }}"
   failed_when:


### PR DESCRIPTION
#### What does this PR do?
Makes the oc action handling more robust to allow for additional helm actions (that doesn't require `oc apply`, etc.) in the future

#### How should this be tested?
Run the tests in the `tests` area of this repo - existing helm and template tests should cover this change.

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @jfilipcz 
